### PR TITLE
Call methods of `Result` on UI thread

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.os.operando.advertisingid'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.30'
+    ext.kotlin_version = '1.3.40'
     repositories {
         google()
         jcenter()

--- a/android/src/main/kotlin/com/os/operando/advertisingid/AdvertisingIdPlugin.kt
+++ b/android/src/main/kotlin/com/os/operando/advertisingid/AdvertisingIdPlugin.kt
@@ -22,9 +22,14 @@ class AdvertisingIdPlugin(private val registrar: Registrar) : MethodCallHandler 
         when (call.method) {
             "getAdvertisingId" -> thread {
                 try {
-                    result.success(AdvertisingIdClient.getAdvertisingIdInfo(registrar.context()).id)
+                    val id = AdvertisingIdClient.getAdvertisingIdInfo(registrar.context()).id
+                    registrar.activity().runOnUiThread {
+                        result.success(id)
+                    }
                 } catch (e: Exception) {
-                    result.success("")
+                    registrar.activity().runOnUiThread {
+                        result.error(e.javaClass.canonicalName, e.localizedMessage, null)
+                    }
                 }
             }
             else -> result.notImplemented()


### PR DESCRIPTION
We need call `Result#success` and `Result#error` on UI thread.

see:
https://github.com/flutter/engine/pull/8947


I fixed calling these methods on UI thread.

And version up kotlin on the way.
