### PR TITLE
Adding iOS 14 support to get IDFA

### DIFF
--- a/ios/Classes/SwiftAdvertisingIdPlugin.swift
+++ b/ios/Classes/SwiftAdvertisingIdPlugin.swift
@@ -1,6 +1,7 @@
 import Flutter
 import UIKit
 import AdSupport
+import AppTrackingTransparency
 
 public class SwiftAdvertisingIdPlugin: NSObject, FlutterPlugin {
     public static func register(with registrar: FlutterPluginRegistrar) {
@@ -12,14 +13,28 @@ public class SwiftAdvertisingIdPlugin: NSObject, FlutterPlugin {
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         switch call.method {
         case "getAdvertisingId":
-            var idfaString: String!
             let manager = ASIdentifierManager.shared()
-            if manager.isAdvertisingTrackingEnabled {
-                idfaString = manager.advertisingIdentifier.uuidString
+            if #available(iOS 14.0, *) {
+                ATTrackingManager.requestTrackingAuthorization { status in
+                    var idfaString = ""
+                    switch status {
+                        case .authorized:
+                            idfaString = manager.advertisingIdentifier.uuidString
+                            break
+                        @unknown default:
+                            break
+                    }
+                    result(idfaString) 
+                }
             } else {
-                idfaString = ""
-            }
-            result(idfaString)
+                var idfaString: String!
+                if manager.isAdvertisingTrackingEnabled {
+                    idfaString = manager.advertisingIdentifier.uuidString
+                } else {
+                    idfaString = ""
+                }
+                result(idfaString)
+            }            
         case "isLimitAdTrackingEnabled":
             result(ASIdentifierManager.shared().isAdvertisingTrackingEnabled)
         default:

--- a/ios/Classes/SwiftAdvertisingIdPlugin.swift
+++ b/ios/Classes/SwiftAdvertisingIdPlugin.swift
@@ -15,17 +15,21 @@ public class SwiftAdvertisingIdPlugin: NSObject, FlutterPlugin {
         case "getAdvertisingId":
             let manager = ASIdentifierManager.shared()
             if #available(iOS 14.0, *) {
-                ATTrackingManager.requestTrackingAuthorization { status in
-                    var idfaString = ""
-                    switch status {
-                        case .authorized:
-                            idfaString = manager.advertisingIdentifier.uuidString
-                            break
-                        @unknown default:
-                            break
+                if (ATTrackingManager.trackingAuthorizationStatus == ATTrackingManager.AuthorizationStatus.authorized) {
+                    result(manager.advertisingIdentifier.uuidString)
+                } else {
+                    ATTrackingManager.requestTrackingAuthorization { status in
+                        var idfaString = ""
+                        switch status {
+                            case .authorized:
+                                idfaString = manager.advertisingIdentifier.uuidString
+                                break
+                            @unknown default:
+                                break
+                        }
+                        result(idfaString)
                     }
-                    result(idfaString) 
-                }
+                }                
             } else {
                 var idfaString: String!
                 if manager.isAdvertisingTrackingEnabled {
@@ -36,7 +40,11 @@ public class SwiftAdvertisingIdPlugin: NSObject, FlutterPlugin {
                 result(idfaString)
             }            
         case "isLimitAdTrackingEnabled":
-            result(ASIdentifierManager.shared().isAdvertisingTrackingEnabled)
+            if #available(iOS 14.0, *) {
+                result(ATTrackingManager.trackingAuthorizationStatus == ATTrackingManager.AuthorizationStatus.authorized)
+            } else {
+                result(ASIdentifierManager.shared().isAdvertisingTrackingEnabled)
+            }
         default:
             result(nil)
         }


### PR DESCRIPTION
Based on the article: https://medium.com/@nish.bhasin/how-to-get-idfa-in-ios14-54f7ea02aa42

Apps targeted towards iOS14 will need to use AppTrackingTransparency framework along with AdSupport framework to get the IDFA, and also will need to ask for permission to track the user activity on the app. I've implemented the adjustments needed to keep the advertising_id plugin working.

Keep in mind that improvement requires the dev to add the NSUserTrackingUsageDescription at Info.plist file.

```
<key>NSUserTrackingUsageDescription</key>
<string>App would like to access IDFA for tracking purpose</string>
```

