### PR TITLE
Support AndroidX

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,7 +32,7 @@ android {
     }
     defaultConfig {
         minSdkVersion 16
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     lintOptions {
         disable 'InvalidPackage'

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,1 +1,3 @@
+android.enableJetifier=true
+android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536M

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -13,7 +13,6 @@
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
     <application
-        android:name="io.flutter.app.FlutterApplication"
         android:label="advertising_id_example"
         android:icon="@mipmap/ic_launcher">
         <activity
@@ -23,13 +22,9 @@
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density"
             android:hardwareAccelerated="true"
             android:windowSoftInputMode="adjustResize">
-            <!-- This keeps the window background of the activity showing
-                 until Flutter renders its first frame. It can be removed if
-                 there is no splash screen (such as the default splash screen
-                 defined in @style/LaunchTheme). -->
             <meta-data
-                android:name="io.flutter.app.android.SplashScreenUntilFirstFrame"
-                android:value="true" />
+                    android:name="flutterEmbedding"
+                    android:value="2" />
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>

--- a/example/android/app/src/main/kotlin/com/os/operando/advertisingidexample/MainActivity.kt
+++ b/example/android/app/src/main/kotlin/com/os/operando/advertisingidexample/MainActivity.kt
@@ -1,13 +1,6 @@
 package com.os.operando.advertisingidexample
 
-import android.os.Bundle
-
-import io.flutter.app.FlutterActivity
-import io.flutter.plugins.GeneratedPluginRegistrant
+import io.flutter.embedding.android.FlutterActivity
 
 class MainActivity(): FlutterActivity() {
-  override fun onCreate(savedInstanceState: Bundle?) {
-    super.onCreate(savedInstanceState)
-    GeneratedPluginRegistrant.registerWith(this)
-  }
 }


### PR DESCRIPTION
Some projects using new Flutter will fail to build because advertising_is doesn't support AndroidX.
I update due to the document below.
https://flutter.dev/docs/development/androidx-migration


Also I update example project due to https://github.com/flutter/flutter/wiki/Upgrading-pre-1.12-Android-projects